### PR TITLE
feat: implement logging with zap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Discord bot built in Go that sends random images from organized local director
 - **Local Image Storage**: Fast, reliable image serving from local directories
 - **Dynamic Command Discovery**: Automatically creates commands based on available image folders
 - **Help System**: Built-in help command to list available image categories
+- **Comprehensive Logging**: Structured logging with Zap for command tracking, user metrics, and performance monitoring
 - **Clean Architecture**: Modular design with separate packages for config, services, handlers, and bot logic
 - **Environment Configuration**: Support for `.env` files and environment variables
 - **Graceful Shutdown**: Proper signal handling for clean shutdowns
@@ -36,6 +37,40 @@ img/
 ```
 
 Supported image formats: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`
+
+## Logging
+
+The bot includes comprehensive structured logging using Zap. Logs include:
+
+- **Command Tracking**: Every command execution with user info, timing, and results
+- **Performance Metrics**: Response times for image operations
+- **User Analytics**: Who is using which commands and when
+- **Error Tracking**: Detailed error information for debugging
+- **System Events**: Bot startup, image service initialization, etc.
+
+### Log Levels
+
+Set the log level using the `LOG_LEVEL` environment variable:
+- `debug` - All messages including debug info
+- `info` - General information (default)
+- `warn` - Warnings and errors
+- `error` - Errors only
+
+### Example Log Output
+
+```json
+{
+  "timestamp": "2024-01-20T10:30:45Z",
+  "level": "info",
+  "message": "Command received",
+  "command": "!wooper",
+  "category": "wooper",
+  "user": "username",
+  "user_id": "123456789",
+  "channel_id": "987654321",
+  "guild_id": "111222333"
+}
+```
 
 ### Adding New Image Categories
 
@@ -122,6 +157,8 @@ wooper-bot/
     │   └── config.go
     ├── handlers/        # Message event handlers
     │   └── messages.go
+    ├── logger/          # Structured logging with Zap
+    │   └── logger.go
     └── services/        # Business logic services
         └── image.go
 ```
@@ -131,8 +168,9 @@ wooper-bot/
 The bot follows a clean, layered architecture:
 
 - **`internal/config`**: Environment variable loading with `.env` support
+- **`internal/logger`**: Structured logging configuration and initialization
 - **`internal/services`**: Business logic for local image management and category discovery
-- **`internal/handlers`**: Discord message event processing with dynamic command support
+- **`internal/handlers`**: Discord message event processing with dynamic command support and comprehensive logging
 - **`internal/bot`**: Discord session management and lifecycle
 - **`main.go`**: Dependency injection and application startup
 
@@ -140,6 +178,7 @@ The bot follows a clean, layered architecture:
 
 - **discordgo**: Discord API client for Go
 - **godotenv**: Environment variable loading from `.env` files
+- **zap**: High-performance structured logging
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 
 require (
 	github.com/gorilla/websocket v1.4.2 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"wooper-bot/internal/logger"
 	"wooper-bot/internal/services"
 
 	"github.com/bwmarrin/discordgo"
+	"go.uber.org/zap"
 )
 
 type MessageHandler struct {
@@ -23,45 +25,113 @@ func (h *MessageHandler) OnMessageCreate(s *discordgo.Session, m *discordgo.Mess
 	if m.Author == nil || m.Author.Bot {
 		return
 	}
+
 	content := strings.TrimSpace(m.Content)
-	
+
+	// Log all messages for debugging (can be filtered by log level)
+	logger.Logger.Debug("Message received",
+		zap.String("user", m.Author.Username),
+		zap.String("user_id", m.Author.ID),
+		zap.String("channel_id", m.ChannelID),
+		zap.String("guild_id", m.GuildID),
+		zap.String("content", content))
+
 	// Check if message starts with ! and has a valid category
 	if strings.HasPrefix(content, "!") {
 		category := strings.TrimPrefix(content, "!")
+
+		// Log command attempt
+		logger.Logger.Info("Command received",
+			zap.String("command", content),
+			zap.String("category", category),
+			zap.String("user", m.Author.Username),
+			zap.String("user_id", m.Author.ID),
+			zap.String("channel_id", m.ChannelID),
+			zap.String("guild_id", m.GuildID))
+
 		if h.ImageService.HasCategory(category) {
+			startTime := time.Now()
+
 			imagePath := h.ImageService.GetRandomImage(category)
 			if imagePath == "" {
+				logger.Logger.Warn("No images available for category",
+					zap.String("category", category),
+					zap.String("user", m.Author.Username))
 				_, _ = s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("no %s images available", category))
 				return
 			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
+
 			reader, fileName, err := h.ImageService.GetImageFile(ctx, imagePath)
 			if err != nil {
+				logger.Logger.Error("Failed to load image file",
+					zap.String("category", category),
+					zap.String("image_path", imagePath),
+					zap.String("user", m.Author.Username),
+					zap.Error(err))
 				_, _ = s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("failed to load %s: %v", category, err))
 				return
 			}
 			defer reader.Close()
+
 			_, err = s.ChannelMessageSendComplex(m.ChannelID, &discordgo.MessageSend{Files: []*discordgo.File{{
 				Name:   fileName,
 				Reader: reader,
 			}}})
+
+			duration := time.Since(startTime)
+
 			if err != nil {
+				logger.Logger.Error("Failed to send image",
+					zap.String("category", category),
+					zap.String("filename", fileName),
+					zap.String("user", m.Author.Username),
+					zap.Duration("duration", duration),
+					zap.Error(err))
 				_, _ = s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("failed to send %s: %v", category, err))
+			} else {
+				logger.Logger.Info("Image sent successfully",
+					zap.String("category", category),
+					zap.String("filename", fileName),
+					zap.String("user", m.Author.Username),
+					zap.String("user_id", m.Author.ID),
+					zap.String("channel_id", m.ChannelID),
+					zap.Duration("duration", duration))
 			}
 		} else if category == "help" || category == "list" {
 			// Show available categories
+			logger.Logger.Info("Help command requested",
+				zap.String("user", m.Author.Username),
+				zap.String("user_id", m.Author.ID))
+
 			categories := h.ImageService.GetAvailableCategories()
 			if len(categories) == 0 {
+				logger.Logger.Warn("No categories available for help",
+					zap.String("user", m.Author.Username))
 				_, _ = s.ChannelMessageSend(m.ChannelID, "no image categories available")
 				return
 			}
+
 			message := "Available image categories:\n"
 			for _, cat := range categories {
 				count := h.ImageService.GetImageCount(cat)
 				message += fmt.Sprintf("• `!%s` (%d images)\n", cat, count)
 			}
+
+			logger.Logger.Info("Help response sent",
+				zap.String("user", m.Author.Username),
+				zap.Int("categories_count", len(categories)))
+
 			_, _ = s.ChannelMessageSend(m.ChannelID, message)
+		} else {
+			// Unknown command
+			logger.Logger.Info("Unknown command received",
+				zap.String("command", content),
+				zap.String("category", category),
+				zap.String("user", m.Author.Username),
+				zap.String("user_id", m.Author.ID))
 		}
 	}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,57 @@
+package logger
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var Logger *zap.Logger
+
+func Init() error {
+	config := zap.NewProductionConfig()
+
+	// Set log level from environment variable
+	level := os.Getenv("LOG_LEVEL")
+	if level == "" {
+		level = "info"
+	}
+
+	var zapLevel zapcore.Level
+	switch level {
+	case "debug":
+		zapLevel = zapcore.DebugLevel
+	case "info":
+		zapLevel = zapcore.InfoLevel
+	case "warn":
+		zapLevel = zapcore.WarnLevel
+	case "error":
+		zapLevel = zapcore.ErrorLevel
+	default:
+		zapLevel = zapcore.InfoLevel
+	}
+	config.Level = zap.NewAtomicLevelAt(zapLevel)
+
+	// Configure output format
+	config.EncoderConfig.TimeKey = "timestamp"
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	config.EncoderConfig.LevelKey = "level"
+	config.EncoderConfig.MessageKey = "message"
+	config.EncoderConfig.CallerKey = "caller"
+	config.EncoderConfig.StacktraceKey = "stacktrace"
+
+	var err error
+	Logger, err = config.Build()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Close() {
+	if Logger != nil {
+		Logger.Sync()
+	}
+}

--- a/internal/services/image.go
+++ b/internal/services/image.go
@@ -9,6 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"wooper-bot/internal/logger"
+
+	"go.uber.org/zap"
 )
 
 type ImageService struct {
@@ -16,12 +20,15 @@ type ImageService struct {
 }
 
 func NewImageService(baseDir string) (*ImageService, error) {
+	logger.Logger.Info("Initializing image service", zap.String("base_dir", baseDir))
+
 	service := &ImageService{
 		categories: make(map[string][]string),
 	}
 
 	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			logger.Logger.Error("Error walking directory", zap.String("path", path), zap.Error(err))
 			return err
 		}
 		if info.IsDir() {
@@ -33,24 +40,41 @@ func NewImageService(baseDir string) (*ImageService, error) {
 			// Extract category from path (e.g., img/wooper/image.jpg -> wooper)
 			relPath, err := filepath.Rel(baseDir, path)
 			if err != nil {
+				logger.Logger.Error("Error getting relative path", zap.String("path", path), zap.Error(err))
 				return err
 			}
 			parts := strings.Split(relPath, string(filepath.Separator))
 			if len(parts) >= 2 {
 				category := parts[0]
 				service.categories[category] = append(service.categories[category], path)
+				logger.Logger.Debug("Found image",
+					zap.String("category", category),
+					zap.String("file", filepath.Base(path)),
+					zap.String("path", path))
 			}
 		}
 		return nil
 	})
 
 	if err != nil {
+		logger.Logger.Error("Error scanning image directory", zap.Error(err))
 		return nil, fmt.Errorf("scan image directory: %w", err)
 	}
 
 	if len(service.categories) == 0 {
+		logger.Logger.Error("No image categories found", zap.String("base_dir", baseDir))
 		return nil, fmt.Errorf("no image categories found in directory: %s", baseDir)
 	}
+
+	// Log summary of loaded categories
+	for category, images := range service.categories {
+		logger.Logger.Info("Loaded image category",
+			zap.String("category", category),
+			zap.Int("count", len(images)))
+	}
+
+	logger.Logger.Info("Image service initialized successfully",
+		zap.Int("total_categories", len(service.categories)))
 
 	return service, nil
 }
@@ -58,19 +82,31 @@ func NewImageService(baseDir string) (*ImageService, error) {
 func (s *ImageService) GetRandomImage(category string) string {
 	images, exists := s.categories[category]
 	if !exists || len(images) == 0 {
+		logger.Logger.Warn("No images found for category", zap.String("category", category))
 		return ""
 	}
 	rand.Seed(time.Now().UnixNano())
-	return images[rand.Intn(len(images))]
+	selectedImage := images[rand.Intn(len(images))]
+	logger.Logger.Debug("Selected random image",
+		zap.String("category", category),
+		zap.String("image", filepath.Base(selectedImage)),
+		zap.Int("total_available", len(images)))
+	return selectedImage
 }
 
 func (s *ImageService) GetImageFile(ctx context.Context, imagePath string) (io.ReadCloser, string, error) {
+	logger.Logger.Debug("Opening image file", zap.String("path", imagePath))
+
 	file, err := os.Open(imagePath)
 	if err != nil {
+		logger.Logger.Error("Failed to open image file", zap.String("path", imagePath), zap.Error(err))
 		return nil, "", fmt.Errorf("open image file: %w", err)
 	}
 
 	fileName := filepath.Base(imagePath)
+	logger.Logger.Debug("Successfully opened image file",
+		zap.String("filename", fileName),
+		zap.String("path", imagePath))
 
 	return file, fileName, nil
 }

--- a/main.go
+++ b/main.go
@@ -9,32 +9,45 @@ import (
 	"wooper-bot/internal/bot"
 	"wooper-bot/internal/config"
 	"wooper-bot/internal/handlers"
+	"wooper-bot/internal/logger"
 	"wooper-bot/internal/services"
+
+	"go.uber.org/zap"
 )
 
 func main() {
+	// Initialize logging
+	if err := logger.Init(); err != nil {
+		log.Fatalf("logger init error: %v", err)
+	}
+	defer logger.Close()
+
+	logger.Logger.Info("Starting wooper-bot")
+
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("config error: %v", err)
+		logger.Logger.Fatal("config error", zap.Error(err))
 	}
 
 	imageService, err := services.NewImageService("img")
 	if err != nil {
-		log.Fatalf("image service error: %v", err)
+		logger.Logger.Fatal("image service error", zap.Error(err))
 	}
 
 	messageHandler := handlers.NewMessageHandler(imageService)
 
 	b, err := bot.New(cfg.DiscordBotToken)
 	if err != nil {
-		log.Fatalf("bot error: %v", err)
+		logger.Logger.Fatal("bot error", zap.Error(err))
 	}
 	b.AddHandler(messageHandler.OnMessageCreate)
+
+	logger.Logger.Info("Bot initialized successfully")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	if err := b.Start(ctx); err != nil {
-		log.Fatalf("run error: %v", err)
+		logger.Logger.Fatal("run error", zap.Error(err))
 	}
 }


### PR DESCRIPTION
This pull request adds comprehensive structured logging to the Discord bot using the Zap library, significantly improving observability and debugging capabilities. Logging is now integrated throughout the bot's lifecycle, command handling, and image service operations. The documentation and project structure have also been updated to reflect these changes.

**Logging Integration and Observability**
* Introduced a new `internal/logger` package with Zap-based structured logging, configurable via the `LOG_LEVEL` environment variable. Logging covers command tracking, user analytics, performance metrics, error tracking, and system events. [[1]](diffhunk://#diff-686bf1c28b7f93841338199e02e03ed12f96fea2e717a8ce80eb80d44b7c09baR1-R57) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41-R74) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171-R181)
* Replaced all legacy `log` calls in `main.go` with Zap logging, including startup, configuration, service initialization, and shutdown events.

**Command and Event Logging**
* Added detailed logging to `internal/handlers/messages.go` for all Discord message events, command executions, help requests, image sends, errors, and unknown commands, capturing user and context metadata.

**Image Service Logging**
* Enhanced `internal/services/image.go` with logs for image service initialization, category discovery, image selection, file operations, and error handling. [[1]](diffhunk://#diff-ad63ec1700181564e854dfb24d88c8fa7895befc96c18dee34e69849541e6216R12-R31) [[2]](diffhunk://#diff-ad63ec1700181564e854dfb24d88c8fa7895befc96c18dee34e69849541e6216R43-R109)

**Documentation and Dependency Updates**
* Updated `README.md` to document the new logging features, configuration options, and example outputs. Added Zap to the dependencies and described the new `internal/logger` package. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160-R161) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171-R181) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R12-R13)