### PR TITLE
feat: add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
 run: ## Run the bot
-	go run .
+	go run ./...
 
 build: ## Build the binary
 	go build -o wooper-bot .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Wooper Bot Makefile
+
+.PHONY: run build test fmt clean help
+
+# Default target
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@echo "Available commands:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+run: ## Run the bot
+	go run .
+
+build: ## Build the binary
+	go build -o wooper-bot .
+
+test: ## Run tests
+	go test ./...
+
+fmt: ## Format code
+	go fmt ./...
+
+clean: ## Clean build artifacts
+	go clean
+	rm -f wooper-bot

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ The bot will automatically detect the new category and make it available as a co
 
 4. **Run the bot**
    ```bash
+   make run
+   ```
+
+   Or use the traditional Go command:
+   ```bash
    go run ./...
    ```
 
@@ -182,15 +187,32 @@ The bot follows a clean, layered architecture:
 
 ## Development
 
+### Makefile Commands
+
+The project includes a simple Makefile for common development tasks:
+
+```bash
+make help    # Show available commands
+make run     # Run the bot
+make build   # Build the binary
+make test    # Run tests
+make fmt     # Format code
+make clean   # Clean build artifacts
+```
+
 ### Building
 
 ```bash
+make build
+# or
 go build -o wooper-bot .
 ```
 
 ### Running Tests
 
 ```bash
+make test
+# or
 go test ./...
 ```
 


### PR DESCRIPTION
This pull request introduces a Makefile to streamline common development tasks for the Wooper Bot project and updates the `README.md` to document these new commands. These changes make it easier for developers to build, run, test, and maintain the project using simple, standardized commands.

**Tooling and workflow improvements:**

* Added a new `Makefile` with targets for running the bot, building the binary, running tests, formatting code, cleaning build artifacts, and displaying help information.

**Documentation updates:**

* Updated the `README.md` to include instructions for running the bot using `make run` and to document all available Makefile commands for development tasks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R120-R124) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R190-R215)